### PR TITLE
Update volunteer.py

### DIFF
--- a/gonullu/volunteer.py
+++ b/gonullu/volunteer.py
@@ -41,7 +41,8 @@ class Volunteer(Docker):
 
         with open(config_file, 'r') as sandbox_file:
             try:
-                if self.package in yaml.load(sandbox_file):
+                #FIXME! yaml.load(input) is depricated
+                if self.package in yaml.load(sandbox_file, Loader=yaml.FullLoader):
                     return False
             except:
                 self.log.error(message='%s dosyası işlenemedi' % config_file)


### PR DESCRIPTION
Following error fixed:
sudo gonullu
Parola: 
Namespace(cpu_set=1, email='ilkermanap@gmail.com', job=5, memory_limit=80, usage=False)
  [*] Bilgi: Yeni paket bulundu, paketin adı: python-PyYAML
/usr/lib/python3.6/site-packages/gonullu/volunteer.py:44: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  if self.package in yaml.load(sandbox_file):